### PR TITLE
chore(ci): focus CodeQL on security queries only

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          queries: +security-and-quality
+          queries: security-extended
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5


### PR DESCRIPTION
## Summary
- Switches CodeQL query suite from `+security-and-quality` to `security-extended`
- Eliminates recurring code-quality noise (cs/useless-upcast and similar rules) from the alert backlog
- Security findings are unaffected; only quality-category rules are removed

## Test plan
- [ ] Verify CodeQL workflow runs successfully after merge
- [ ] Confirm no new security alerts are suppressed (only quality-category rules removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)